### PR TITLE
Improve error handling and email visibility in core.py

### DIFF
--- a/toutatis/core.py
+++ b/toutatis/core.py
@@ -122,7 +122,7 @@ def main():
     # print("Number of tag in posts : "+str(infos["following_tag_count"]))
     if infos["external_url"]:
         print("External url           : " + infos["external_url"])
-    print("IGTV posts             : " + str(infos["total_igtv_videos"]))
+    print("IGTV posts             : " + str(infos.get("total_igtv_videos", 0)))
     print("Biography              : " + (f"""\n{" " * 25}""").join(infos["biography"].split("\n")))
     print("Linked WhatsApp        : " + str(infos["is_whatsapp_linked"]))
     print("Memorial Account       : " + str(infos["is_memorialized"]))
@@ -131,6 +131,10 @@ def main():
     if "public_email" in infos.keys():
         if infos["public_email"]:
             print("Public Email           : " + infos["public_email"])
+        else:
+            print("Public Email           : None")
+    else:
+        print("Public Email           : Not available")
 
     if "public_phone_number" in infos.keys():
         if str(infos["public_phone_number"]):
@@ -160,7 +164,9 @@ def main():
             if other_infos["user"]["obfuscated_email"]:
                 print("Obfuscated email       : " + other_infos["user"]["obfuscated_email"])
             else:
-                print("No obfuscated email found")
+                print("Obfuscated email       : None")
+        else:
+            print("Obfuscated email       : Not available")
 
         if "obfuscated_phone" in other_infos["user"].keys():
             if str(other_infos["user"]["obfuscated_phone"]):


### PR DESCRIPTION
This PR addresses a KeyError crash and enhances email reporting visibility. The tool previously crashed on certain accounts due to missing API fields, and email status was not always reported.

**Issue Fixed:** The following error occurred when running the tool on some accounts (e.g., private accounts without IGTV data):

Informations about     : [username redacted]
userID                 : [userID redacted]
Full Name              : [full name redacted]
Verified               : False | Is buisness Account : False
Is private Account     : True
Follower               : 7 | Following : 12
Number of posts        : 0
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/toutatis/core.py", line 125, in <module>
    sys.exit(load_entry_point('toutatis==1.31', 'console_scripts', 'toutatis')())
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/toutatis/core.py", line 125, in main
    print("IGTV posts             : " + str(infos["total_igtv_videos"]))
                                            ~~~~~^^^^^^^^^^^^^^^^^^^^^
KeyError: 'total_igtv_videos'

**Changes Made:**

1. Fixed KeyError by using safe dictionary access for 'total_igtv_videos'. 
2. Enhanced public email reporting to always indicate presence/absence. 
3. Enhanced obfuscated email reporting to always indicate presence/absence. 


Benefits: Prevents crashes, improves robustness, and provides clearer output for users.

Files Changed: toutatis/toutatis/core.py

**Testing: Verified on multiple usernames; no crashes, and email status is now always reported.**